### PR TITLE
Update versions upper bounds (and change * to Type)

### DIFF
--- a/Control/Monad/Stack/Accum.hs
+++ b/Control/Monad/Stack/Accum.hs
@@ -25,8 +25,10 @@ import Control.Monad.Trans.Writer.CPS as WC
 import Control.Monad.Trans.Writer.Lazy as WL
 import Control.Monad.Trans.Writer.Strict as WS
 
+import Data.Kind
+
 class Monad m => AccumStack m where
-	type PopAccum m :: * -> *
+	type PopAccum m :: Type -> Type
 	liftAccum :: PopAccum m a -> m a
 
 type instance Pop AccumT m = PopAccum m

--- a/Control/Monad/Stack/Cont.hs
+++ b/Control/Monad/Stack/Cont.hs
@@ -27,8 +27,10 @@ import Control.Monad.Trans.Writer.CPS as WC
 import Control.Monad.Trans.Writer.Lazy as WL
 import Control.Monad.Trans.Writer.Strict as WS
 
+import Data.Kind
+
 class Monad m => ContStack m where
-	type PopCont m :: * -> *
+	type PopCont m :: Type -> Type
 	liftCont :: PopCont m a -> m a
 
 type instance Pop ContTag m = PopCont m

--- a/Control/Monad/Stack/Error.hs
+++ b/Control/Monad/Stack/Error.hs
@@ -27,8 +27,10 @@ import Control.Monad.Trans.Writer.CPS as WC
 import Control.Monad.Trans.Writer.Lazy as WL
 import Control.Monad.Trans.Writer.Strict as WS
 
+import Data.Kind
+
 class Monad m => ErrorStack m where
-	type PopError m :: * -> *
+	type PopError m :: Type -> Type
 	liftError :: PopError m a -> m a
 
 type instance Pop ExceptT m = PopError m

--- a/Control/Monad/Stack/Fail.hs
+++ b/Control/Monad/Stack/Fail.hs
@@ -27,8 +27,10 @@ import Control.Monad.Trans.Writer.CPS as WC
 import Control.Monad.Trans.Writer.Lazy as WL
 import Control.Monad.Trans.Writer.Strict as WS
 
+import Data.Kind
+
 class Monad m => FailStack m where
-	type PopFail m :: * -> *
+	type PopFail m :: Type -> Type
 	liftFail :: PopFail m a -> m a
 
 type instance Pop MaybeT m = PopFail m

--- a/Control/Monad/Stack/Reader.hs
+++ b/Control/Monad/Stack/Reader.hs
@@ -27,8 +27,10 @@ import Control.Monad.Trans.Writer.CPS as WC
 import Control.Monad.Trans.Writer.Lazy as WL
 import Control.Monad.Trans.Writer.Strict as WS
 
+import Data.Kind
+
 class Monad m => ReaderStack m where
-	type PopReader m :: * -> *
+	type PopReader m :: Type -> Type
 	liftReader :: PopReader m a -> m a
 
 type instance Pop ReaderT m = PopReader m

--- a/Control/Monad/Stack/Select.hs
+++ b/Control/Monad/Stack/Select.hs
@@ -25,8 +25,10 @@ import Control.Monad.Trans.Writer.CPS as WC
 import Control.Monad.Trans.Writer.Lazy as WL
 import Control.Monad.Trans.Writer.Strict as WS
 
+import Data.Kind
+
 class Monad m => SelectStack m where
-	type PopSelect m :: * -> *
+	type PopSelect m :: Type -> Type
 	liftSelect :: PopSelect m a -> m a
 
 type instance Pop SelectT m = PopSelect m

--- a/Control/Monad/Stack/State.hs
+++ b/Control/Monad/Stack/State.hs
@@ -27,8 +27,10 @@ import Control.Monad.Trans.Writer.CPS as WC
 import Control.Monad.Trans.Writer.Lazy as WL
 import Control.Monad.Trans.Writer.Strict as WS
 
+import Data.Kind
+
 class Monad m => StateStack m where
-	type PopState m :: * -> *
+	type PopState m :: Type -> Type
 	liftState :: PopState m a -> m a
 
 type instance Pop SL.StateT m = PopState m

--- a/Control/Monad/Stack/Writer.hs
+++ b/Control/Monad/Stack/Writer.hs
@@ -27,8 +27,10 @@ import Control.Monad.Trans.Writer.CPS as WC
 import Control.Monad.Trans.Writer.Lazy as WL
 import Control.Monad.Trans.Writer.Strict as WS
 
+import Data.Kind
+
 class Monad m => WriterStack m where
-	type PopWriter m :: * -> *
+	type PopWriter m :: Type -> Type
 	liftWriter :: PopWriter m a -> m a
 
 type instance Pop WL.WriterT m = PopWriter m

--- a/effect-stack.cabal
+++ b/effect-stack.cabal
@@ -69,9 +69,9 @@ library
                        TypeOperators,
                        UndecidableInstances
   build-depends:
-                       base ^>=4.12,
-                       constraints ^>=0.11,
-                       mtl ^>= 2.2,
-                       transformers ^>=0.5.6
+                       base >= 4.12 && <= 4.20.0.0,
+                       constraints >= 0.11 && <= 0.14.2,
+                       mtl >= 2.2 && <= 2.3.1,
+                       transformers >= 0.5.6 && <= 0.6.1.1
   default-language:    Haskell2010
   ghc-options:         -fno-warn-tabs


### PR DESCRIPTION
Hi, I was trying this library of yours [as you suggested a few months ago](https://stackoverflow.com/questions/79318638/how-can-i-use-the-state-monad-or-the-statet-monad-transformer-to-mimic-the-io#comment139905617_79318638).

Can we bump up the constraint on the version? I've also taken the liberty of chaning `*` to `Data.Kind.Type`.